### PR TITLE
Implement basic image merging workflow

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -1,21 +1,46 @@
-//
-//  ContentView.swift
-//  MergePictures
-//
-//  Created by zhb on 2025/7/27.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var viewModel = AppViewModel()
+
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            StepIndicator(current: $viewModel.step)
+            Divider()
+            content
+            Spacer()
+            HStack {
+                if viewModel.step != .selectImages {
+                    Button("Back") {
+                        if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
+                            viewModel.step = prev
+                        }
+                    }
+                }
+                Spacer()
+                if viewModel.step != .export {
+                    Button("Next") {
+                        if let next = Step(rawValue: viewModel.step.rawValue + 1) {
+                            viewModel.step = next
+                        }
+                    }
+                }
+            }.padding(.top)
         }
         .padding()
+        .frame(minWidth: 600, minHeight: 400)
+    }
+
+    @ViewBuilder
+    var content: some View {
+        switch viewModel.step {
+        case .selectImages:
+            Step1View(viewModel: viewModel)
+        case .previewAll:
+            Step2View(viewModel: viewModel)
+        case .export:
+            Step3View(viewModel: viewModel)
+        }
     }
 }
 

--- a/MergePictures/Model/MergeDirection.swift
+++ b/MergePictures/Model/MergeDirection.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum MergeDirection: String, CaseIterable, Identifiable {
+    case vertical
+    case horizontal
+
+    var id: String { rawValue }
+}

--- a/MergePictures/Model/Step.swift
+++ b/MergePictures/Model/Step.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum Step: Int, CaseIterable {
+    case selectImages = 0
+    case previewAll
+    case export
+
+    var title: String {
+        switch self {
+        case .selectImages:
+            return "Select"
+        case .previewAll:
+            return "Preview"
+        case .export:
+            return "Export"
+        }
+    }
+}

--- a/MergePictures/ViewModel/AppViewModel.swift
+++ b/MergePictures/ViewModel/AppViewModel.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import Combine
+
+class AppViewModel: ObservableObject {
+    @Published var step: Step = .selectImages
+    @Published var mergeCount: Int = 2
+    @Published var direction: MergeDirection = .vertical
+    @Published var images: [NSImage] = [] {
+        didSet { updatePreview() }
+    }
+    @Published var mergedImages: [NSImage] = []
+    @Published var previewImage: NSImage?
+    @Published var maxFileSizeKB: Int = 1024
+
+    func addImages(urls: [URL]) {
+        let newImages = urls.compactMap { NSImage(contentsOf: $0) }
+        images.append(contentsOf: newImages)
+    }
+
+    func updatePreview() {
+        let previewSource = Array(images.prefix(mergeCount))
+        previewImage = merge(images: previewSource, direction: direction)
+    }
+
+    func batchMerge() {
+        mergedImages = []
+        var index = 0
+        while index < images.count {
+            let slice = Array(images[index..<min(index+mergeCount, images.count)])
+            if let merged = merge(images: slice, direction: direction) {
+                mergedImages.append(merged)
+            }
+            index += mergeCount
+        }
+    }
+
+    func merge(images: [NSImage], direction: MergeDirection) -> NSImage? {
+        guard !images.isEmpty else { return nil }
+        let totalSize = images.reduce(CGSize.zero) { partial, image in
+            switch direction {
+            case .horizontal:
+                return CGSize(width: partial.width + image.size.width, height: max(partial.height, image.size.height))
+            case .vertical:
+                return CGSize(width: max(partial.width, image.size.width), height: partial.height + image.size.height)
+            }
+        }
+        let result = NSImage(size: totalSize)
+        result.lockFocus()
+        var current = CGPoint.zero
+        for image in images {
+            image.draw(at: current, from: .zero, operation: .sourceOver, fraction: 1.0)
+            switch direction {
+            case .horizontal:
+                current.x += image.size.width
+            case .vertical:
+                current.y += image.size.height
+            }
+        }
+        result.unlockFocus()
+        return result
+    }
+
+    func compress(image: NSImage, maxSizeKB: Int) -> Data? {
+        guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else {
+            return nil
+        }
+        var quality: CGFloat = 1.0
+        var data = rep.representation(using: .jpeg, properties: [.compressionFactor: quality])
+        while let d = data, d.count > maxSizeKB * 1024, quality > 0.1 {
+            quality -= 0.1
+            data = rep.representation(using: .jpeg, properties: [.compressionFactor: quality])
+        }
+        return data
+    }
+}

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct Step1View: View {
+    @ObservedObject var viewModel: AppViewModel
+    @State private var showImporter = false
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Button("Add Images") { showImporter = true }
+                Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10, onEditingChanged: { _ in viewModel.updatePreview() })
+                Picker("Direction", selection: $viewModel.direction) {
+                    ForEach(MergeDirection.allCases) { dir in
+                        Text(dir.rawValue.capitalized).tag(dir)
+                    }
+                }.pickerStyle(SegmentedPickerStyle())
+            }
+            if let img = viewModel.previewImage {
+                Image(nsImage: img)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 200)
+            } else {
+                Text("No Preview")
+                    .frame(maxHeight: 200)
+            }
+        }
+        .fileImporter(isPresented: $showImporter, allowedContentTypes: [.image], allowsMultipleSelection: true) { result in
+            if case let .success(urls) = result {
+                viewModel.addImages(urls: urls)
+            }
+        }
+    }
+}

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct Step2View: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))]) {
+                ForEach(Array(viewModel.mergedImages.enumerated()), id: \.offset) { idx, img in
+                    Image(nsImage: img)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 150)
+                        .overlay(Text("\(idx+1)").foregroundColor(.white).padding(4), alignment: .bottomTrailing)
+                }
+            }
+        }
+        .onAppear {
+            viewModel.batchMerge()
+        }
+    }
+}

--- a/MergePictures/Views/Step3View.swift
+++ b/MergePictures/Views/Step3View.swift
@@ -1,0 +1,32 @@
+import AppKit
+import SwiftUI
+
+struct Step3View: View {
+    @ObservedObject var viewModel: AppViewModel
+    @State private var exported = false
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Stepper("Max KB: \(viewModel.maxFileSizeKB)", value: $viewModel.maxFileSizeKB, in: 100...10000, step: 100)
+            Button("Export") { exportImages() }
+            if exported {
+                Text("Export Completed!").foregroundColor(.green)
+            }
+        }
+    }
+
+    func exportImages() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let dir = panel.url {
+            for (idx, img) in viewModel.mergedImages.enumerated() {
+                let data = viewModel.compress(image: img, maxSizeKB: viewModel.maxFileSizeKB) ?? img.tiffRepresentation!
+                let url = dir.appendingPathComponent("merged_\(idx).jpg")
+                try? data.write(to: url)
+            }
+            exported = true
+        }
+    }
+}

--- a/MergePictures/Views/StepIndicator.swift
+++ b/MergePictures/Views/StepIndicator.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct StepIndicator: View {
+    @Binding var current: Step
+
+    var body: some View {
+        HStack {
+            ForEach(Step.allCases, id: \.self) { step in
+                Text(step.title)
+                    .fontWeight(step == current ? .bold : .regular)
+                    .padding(.horizontal)
+                    .padding(.vertical, 4)
+                    .background(step == current ? Color.accentColor.opacity(0.2) : Color.clear)
+                    .cornerRadius(6)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add step tracking and merge direction models
- implement AppViewModel with merge and compression logic
- create SwiftUI views for each step of the workflow
- update ContentView with step navigation
- fix enumeration and StepIndicator binding issues

## Testing
- `xcodebuild -list -project MergePictures.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885fdef47888321957e075d91eb67cb