### PR TITLE
Implement processing with progress indicators

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -1,21 +1,48 @@
-//
-//  ContentView.swift
-//  MergePictures
-//
-//  Created by zhb on 2025/7/27.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var viewModel = AppViewModel()
+
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            StepIndicator(current: $viewModel.step)
+            Divider()
+            content
+            Spacer()
+            HStack {
+                if viewModel.step != .selectImages {
+                    Button("Back") {
+                        if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
+                            viewModel.step = prev
+                        }
+                    }
+                    .disabled(viewModel.isExporting)
+                }
+                Spacer()
+                if viewModel.step != .export {
+                    Button("Next") {
+                        if let next = Step(rawValue: viewModel.step.rawValue + 1) {
+                            viewModel.step = next
+                        }
+                    }
+                    .disabled(viewModel.isMerging || viewModel.images.isEmpty)
+                }
+            }.padding(.top)
         }
         .padding()
+        .frame(minWidth: 600, minHeight: 400)
+    }
+
+    @ViewBuilder
+    var content: some View {
+        switch viewModel.step {
+        case .selectImages:
+            Step1View(viewModel: viewModel)
+        case .previewAll:
+            Step2View(viewModel: viewModel)
+        case .export:
+            Step3View(viewModel: viewModel)
+        }
     }
 }
 

--- a/MergePictures/Model/MergeDirection.swift
+++ b/MergePictures/Model/MergeDirection.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum MergeDirection: String, CaseIterable, Identifiable {
+    case vertical
+    case horizontal
+
+    var id: String { rawValue }
+}

--- a/MergePictures/Model/Step.swift
+++ b/MergePictures/Model/Step.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum Step: Int, CaseIterable {
+    case selectImages = 0
+    case previewAll
+    case export
+
+    var title: String {
+        switch self {
+        case .selectImages:
+            return "Select"
+        case .previewAll:
+            return "Preview"
+        case .export:
+            return "Export"
+        }
+    }
+}

--- a/MergePictures/ViewModel/AppViewModel.swift
+++ b/MergePictures/ViewModel/AppViewModel.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import Combine
+
+class AppViewModel: ObservableObject {
+    @Published var step: Step = .selectImages
+    @Published var mergeCount: Int = 2
+    @Published var direction: MergeDirection = .vertical
+    @Published var images: [NSImage] = [] {
+        didSet { updatePreview() }
+    }
+    @Published var mergedImages: [NSImage] = []
+    @Published var previewImage: NSImage?
+    @Published var maxFileSizeKB: Int = 1024
+    @Published var isMerging: Bool = false
+    @Published var mergeProgress: Double = 0
+    @Published var isExporting: Bool = false
+    @Published var exportProgress: Double = 0
+
+    func addImages(urls: [URL]) {
+        let newImages = urls.compactMap { NSImage(contentsOf: $0) }
+        images.append(contentsOf: newImages)
+    }
+
+    func updatePreview() {
+        let previewSource = Array(images.prefix(mergeCount))
+        previewImage = merge(images: previewSource, direction: direction)
+    }
+
+    func batchMerge() {
+        mergedImages = []
+        isMerging = true
+        mergeProgress = 0
+        DispatchQueue.global(qos: .userInitiated).async {
+            var index = 0
+            var results: [NSImage] = []
+            while index < self.images.count {
+                let end = min(index + self.mergeCount, self.images.count)
+                let slice = Array(self.images[index..<end])
+                if let merged = self.merge(images: slice, direction: self.direction) {
+                    results.append(merged)
+                }
+                index += self.mergeCount
+                DispatchQueue.main.async {
+                    self.mergeProgress = Double(index) / Double(self.images.count)
+                }
+            }
+            DispatchQueue.main.async {
+                self.mergedImages = results
+                self.isMerging = false
+                self.mergeProgress = 1.0
+            }
+        }
+    }
+
+    func merge(images: [NSImage], direction: MergeDirection) -> NSImage? {
+        guard !images.isEmpty else { return nil }
+        let totalSize = images.reduce(CGSize.zero) { partial, image in
+            switch direction {
+            case .horizontal:
+                return CGSize(width: partial.width + image.size.width, height: max(partial.height, image.size.height))
+            case .vertical:
+                return CGSize(width: max(partial.width, image.size.width), height: partial.height + image.size.height)
+            }
+        }
+        let result = NSImage(size: totalSize)
+        result.lockFocus()
+        var current = CGPoint.zero
+        for image in images {
+            image.draw(at: current, from: .zero, operation: .sourceOver, fraction: 1.0)
+            switch direction {
+            case .horizontal:
+                current.x += image.size.width
+            case .vertical:
+                current.y += image.size.height
+            }
+        }
+        result.unlockFocus()
+        return result
+    }
+
+    func compress(image: NSImage, maxSizeKB: Int) -> Data? {
+        guard let tiff = image.tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else {
+            return nil
+        }
+        var quality: CGFloat = 1.0
+        var data = rep.representation(using: .jpeg, properties: [.compressionFactor: quality])
+        while let d = data, d.count > maxSizeKB * 1024, quality > 0.1 {
+            quality -= 0.1
+            data = rep.representation(using: .jpeg, properties: [.compressionFactor: quality])
+        }
+        return data
+    }
+
+    func exportAll(to directory: URL) {
+        guard !mergedImages.isEmpty else { return }
+        isExporting = true
+        exportProgress = 0
+        DispatchQueue.global(qos: .userInitiated).async {
+            for (idx, img) in self.mergedImages.enumerated() {
+                let data = self.compress(image: img, maxSizeKB: self.maxFileSizeKB) ?? img.tiffRepresentation!
+                let url = directory.appendingPathComponent("merged_\(idx).jpg")
+                try? data.write(to: url)
+                DispatchQueue.main.async {
+                    self.exportProgress = Double(idx + 1) / Double(self.mergedImages.count)
+                }
+            }
+            DispatchQueue.main.async {
+                self.isExporting = false
+            }
+        }
+    }
+}

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct Step1View: View {
+    @ObservedObject var viewModel: AppViewModel
+    @State private var showImporter = false
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Button("Add Images") { showImporter = true }
+                Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10, onEditingChanged: { _ in viewModel.updatePreview() })
+                .onChange(of: viewModel.mergeCount) { _ in viewModel.updatePreview() }
+                Picker("Direction", selection: $viewModel.direction) {
+                    ForEach(MergeDirection.allCases) { dir in
+                        Text(dir.rawValue.capitalized).tag(dir)
+                    }
+                }.pickerStyle(SegmentedPickerStyle())
+                .onChange(of: viewModel.direction) { _ in viewModel.updatePreview() }
+                Spacer()
+                Text("Selected: \(viewModel.images.count)")
+            }
+            if let img = viewModel.previewImage {
+                Image(nsImage: img)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 200)
+            } else {
+                Text("No Preview")
+                    .frame(maxHeight: 200)
+            }
+        }
+        .fileImporter(isPresented: $showImporter, allowedContentTypes: [.image], allowsMultipleSelection: true) { result in
+            if case let .success(urls) = result {
+                viewModel.addImages(urls: urls)
+            }
+        }
+    }
+}

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct Step2View: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        VStack {
+            if viewModel.isMerging {
+                ProgressView(value: viewModel.mergeProgress)
+                    .padding(.vertical)
+            }
+            ScrollView {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 150))]) {
+                    ForEach(Array(viewModel.mergedImages.enumerated()), id: \.offset) { idx, img in
+                        Image(nsImage: img)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 150)
+                            .overlay(Text("\(idx+1)").foregroundColor(.white).padding(4), alignment: .bottomTrailing)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            if viewModel.mergedImages.isEmpty {
+                viewModel.batchMerge()
+            }
+        }
+    }
+}

--- a/MergePictures/Views/Step3View.swift
+++ b/MergePictures/Views/Step3View.swift
@@ -1,0 +1,30 @@
+import AppKit
+import SwiftUI
+
+struct Step3View: View {
+    @ObservedObject var viewModel: AppViewModel
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Stepper("Max KB: \(viewModel.maxFileSizeKB)", value: $viewModel.maxFileSizeKB, in: 100...10000, step: 100)
+            if viewModel.isExporting {
+                ProgressView(value: viewModel.exportProgress)
+                    .padding(.vertical)
+            }
+            Button("Export") { exportImages() }
+            if viewModel.exportProgress == 1 && !viewModel.isExporting {
+                Text("Export Completed!").foregroundColor(.green)
+            }
+        }
+    }
+
+    func exportImages() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        if panel.runModal() == .OK, let dir = panel.url {
+            viewModel.exportAll(to: dir)
+        }
+    }
+}

--- a/MergePictures/Views/StepIndicator.swift
+++ b/MergePictures/Views/StepIndicator.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct StepIndicator: View {
+    @Binding var current: Step
+
+    var body: some View {
+        HStack {
+            ForEach(Step.allCases, id: \.self) { step in
+                Text(step.title)
+                    .fontWeight(step == current ? .bold : .regular)
+                    .padding(.horizontal)
+                    .padding(.vertical, 4)
+                    .background(step == current ? Color.accentColor.opacity(0.2) : Color.clear)
+                    .cornerRadius(6)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add merging and exporting progress tracking in `AppViewModel`
- update step views to display progress bars
- enable asynchronous batch merge and export operations
- show selected image count and disable navigation during processing

## Testing
- `xcodebuild -list -project MergePictures.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885fdef47888321957e075d91eb67cb