### PR TITLE
Improve responsive UI layout

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -4,30 +4,35 @@ struct ContentView: View {
     @StateObject private var viewModel = AppViewModel()
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             StepIndicator(current: $viewModel.step)
             Divider()
-            content
-            Spacer()
-            HStack {
-                if viewModel.step != .selectImages {
-                    Button("Back") {
-                        if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
-                            viewModel.step = prev
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    content
+                    HStack {
+                        if viewModel.step != .selectImages {
+                            Button("Back") {
+                                if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
+                                    viewModel.step = prev
+                                }
+                            }
+                            .disabled(viewModel.isExporting)
+                        }
+                        Spacer()
+                        if viewModel.step != .export {
+                            Button("Next") {
+                                if let next = Step(rawValue: viewModel.step.rawValue + 1) {
+                                    viewModel.step = next
+                                }
+                            }
+                            .disabled(viewModel.isMerging || viewModel.images.isEmpty)
                         }
                     }
-                    .disabled(viewModel.isExporting)
+                    .padding(.top)
                 }
-                Spacer()
-                if viewModel.step != .export {
-                    Button("Next") {
-                        if let next = Step(rawValue: viewModel.step.rawValue + 1) {
-                            viewModel.step = next
-                        }
-                    }
-                    .disabled(viewModel.isMerging || viewModel.images.isEmpty)
-                }
-            }.padding(.top)
+                .frame(maxWidth: .infinity, alignment: .top)
+            }
         }
         .padding()
         .frame(minWidth: 600, minHeight: 400)

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -5,28 +5,38 @@ struct Step1View: View {
     @State private var showImporter = false
 
     var body: some View {
-        VStack(alignment: .leading) {
-            HStack {
-                Button("Add Images") { showImporter = true }
-                Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10)
-                    .onChange(of: viewModel.mergeCount) { _ in viewModel.updatePreview() }
-                Picker("Direction", selection: $viewModel.direction) {
-                    ForEach(MergeDirection.allCases) { dir in
-                        Text(dir.rawValue.capitalized).tag(dir)
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Button("Add Images") { showImporter = true }
+                        Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10)
+                            .onChange(of: viewModel.mergeCount) { _ in viewModel.updatePreview() }
+                        Picker("Direction", selection: $viewModel.direction) {
+                            ForEach(MergeDirection.allCases) { dir in
+                                Text(dir.rawValue.capitalized).tag(dir)
+                            }
+                        }
+                        .pickerStyle(SegmentedPickerStyle())
+                        .onChange(of: viewModel.direction) { _ in viewModel.updatePreview() }
+                        Spacer()
+                        Text("Selected: \(viewModel.images.count)")
                     }
-                }.pickerStyle(SegmentedPickerStyle())
-                .onChange(of: viewModel.direction) { _ in viewModel.updatePreview() }
-                Spacer()
-                Text("Selected: \(viewModel.images.count)")
-            }
-            if let img = viewModel.previewImage {
-                Image(nsImage: img)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxHeight: 200)
-            } else {
-                Text("No Preview")
-                    .frame(maxHeight: 200)
+                    Group {
+                        if let img = viewModel.previewImage {
+                            Image(nsImage: img)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        } else {
+                            Text("No Preview")
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
+                    }
+                    .frame(minHeight: 200)
+                }
+                .frame(minHeight: proxy.size.height, alignment: .top)
+                .padding(.bottom)
             }
         }
         .fileImporter(isPresented: $showImporter, allowedContentTypes: [.image], allowsMultipleSelection: true) { result in

--- a/MergePictures/Views/Step3View.swift
+++ b/MergePictures/Views/Step3View.swift
@@ -5,16 +5,19 @@ struct Step3View: View {
     @ObservedObject var viewModel: AppViewModel
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Stepper("Max KB: \(viewModel.maxFileSizeKB)", value: $viewModel.maxFileSizeKB, in: 100...10000, step: 100)
-            if viewModel.isExporting {
-                ProgressView(value: viewModel.exportProgress)
-                    .padding(.vertical)
+        ScrollView {
+            VStack(alignment: .leading) {
+                Stepper("Max KB: \(viewModel.maxFileSizeKB)", value: $viewModel.maxFileSizeKB, in: 100...10000, step: 100)
+                if viewModel.isExporting {
+                    ProgressView(value: viewModel.exportProgress)
+                        .padding(.vertical)
+                }
+                Button("Export") { exportImages() }
+                if viewModel.exportProgress == 1 && !viewModel.isExporting {
+                    Text("Export Completed!").foregroundColor(.green)
+                }
             }
-            Button("Export") { exportImages() }
-            if viewModel.exportProgress == 1 && !viewModel.isExporting {
-                Text("Export Completed!").foregroundColor(.green)
-            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 


### PR DESCRIPTION
## Summary
- keep navigation header pinned at the top
- place content inside a ScrollView for scrolling when space is limited
- let image preview expand to fill remaining area
- allow export screen to scroll on small windows

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888556eb9d083218d5d656696d1fe9d