### PR TITLE
Fix Step1View onChange API

### DIFF
--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -9,14 +9,14 @@ struct Step1View: View {
             HStack {
                 Button("Add Images") { showImporter = true }
                 Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10)
-                    .onChange(of: viewModel.mergeCount) { _ in viewModel.updatePreview() }
+                    .onChange(of: viewModel.mergeCount) { _, _ in viewModel.updatePreview() }
                 Picker("Direction", selection: $viewModel.direction) {
                     ForEach(MergeDirection.allCases) { dir in
                         Text(dir.rawValue.capitalized).tag(dir)
                     }
                 }
                 .pickerStyle(SegmentedPickerStyle())
-                .onChange(of: viewModel.direction) { _ in viewModel.updatePreview() }
+                .onChange(of: viewModel.direction) { _, _ in viewModel.updatePreview() }
                 Spacer()
                 Text("Selected: \(viewModel.images.count)")
             }


### PR DESCRIPTION
## Summary
- update Step1View's `onChange` to use the macOS 14 API

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68888780b6c88321a1c931c33e0d75d6