### PR TITLE
Fix preview refresh after editing settings

### DIFF
--- a/MergePictures/ViewModel/AppViewModel.swift
+++ b/MergePictures/ViewModel/AppViewModel.swift
@@ -3,10 +3,26 @@ import Combine
 
 class AppViewModel: ObservableObject {
     @Published var step: Step = .selectImages
-    @Published var mergeCount: Int = 2
-    @Published var direction: MergeDirection = .vertical
+
+    @Published var mergeCount: Int = 2 {
+        didSet {
+            mergedImages = []
+            updatePreview()
+        }
+    }
+
+    @Published var direction: MergeDirection = .vertical {
+        didSet {
+            mergedImages = []
+            updatePreview()
+        }
+    }
+
     @Published var images: [NSImage] = [] {
-        didSet { updatePreview() }
+        didSet {
+            mergedImages = []
+            updatePreview()
+        }
     }
     @Published var mergedImages: [NSImage] = []
     @Published var previewImage: NSImage?

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -9,14 +9,12 @@ struct Step1View: View {
             HStack {
                 Button("Add Images") { showImporter = true }
                 Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10)
-                    .onChange(of: viewModel.mergeCount) { _, _ in viewModel.updatePreview() }
                 Picker("Direction", selection: $viewModel.direction) {
                     ForEach(MergeDirection.allCases) { dir in
                         Text(dir.rawValue.capitalized).tag(dir)
                     }
                 }
                 .pickerStyle(SegmentedPickerStyle())
-                .onChange(of: viewModel.direction) { _, _ in viewModel.updatePreview() }
                 Spacer()
                 Text("Selected: \(viewModel.images.count)")
             }


### PR DESCRIPTION
## Summary
- reset merge results when images, merge count or direction change
- clean up Step1View since update handling moved to view model

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project MergePictures.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888955d053883218f9796dfa22d37f1