### PR TITLE
Adjust preview scaling in Step1

### DIFF
--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -21,13 +21,15 @@ struct Step1View: View {
             GeometryReader { proxy in
                 Group {
                     if let img = viewModel.previewImage {
-                        let containerWidth = proxy.size.width
-                        let minWidth = containerWidth * 0.5
-                        let targetWidth = max(minWidth, min(containerWidth, img.size.width))
-                        let targetHeight = targetWidth * (img.size.height / img.size.width)
+                        let wRatio = proxy.size.width / img.size.width
+                        let hRatio = proxy.size.height / img.size.height
+                        let scale = min(wRatio, hRatio, 1)
+                        let width = img.size.width * scale
+                        let height = img.size.height * scale
                         Image(nsImage: img)
                             .resizable()
-                            .frame(width: targetWidth, height: targetHeight)
+                            .scaledToFit()
+                            .frame(width: width, height: height)
                     } else {
                         Text("No Preview")
                             .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
- scale the preview image using container size so the merged picture fits entirely
- keep app sandbox disabled for file access

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6888bb5128588321be5e7c5aff2acedb