### PR TITLE
Add draggable sidebar for image management

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -7,37 +7,41 @@ struct ContentView: View {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
     var body: some View {
-        VStack(spacing: 10) {
-            StepIndicator(current: $viewModel.step)
+        HStack(spacing: 0) {
+            ImageSidebarView(viewModel: viewModel)
             Divider()
+            VStack(spacing: 10) {
+                StepIndicator(current: $viewModel.step)
+                Divider()
 
-            VStack(alignment: .leading, spacing: 16) {
-                content
-            }
-            .frame(maxWidth: .infinity, alignment: .top)
-            
-            HStack {
-                if viewModel.step != .selectImages {
-                    Button("Back") {
-                        if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
-                            viewModel.step = prev
-                        }
-                    }
-                    .disabled(viewModel.isExporting)
+                VStack(alignment: .leading, spacing: 16) {
+                    content
                 }
-                Spacer()
-                if viewModel.step != .export {
-                    Button("Next") {
-                        if let next = Step(rawValue: viewModel.step.rawValue + 1) {
-                            viewModel.step = next
+                .frame(maxWidth: .infinity, alignment: .top)
+
+                HStack {
+                    if viewModel.step != .selectImages {
+                        Button("Back") {
+                            if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
+                                viewModel.step = prev
+                            }
                         }
+                        .disabled(viewModel.isExporting)
                     }
-                    .disabled(viewModel.isMerging || viewModel.images.isEmpty)
+                    Spacer()
+                    if viewModel.step != .export {
+                        Button("Next") {
+                            if let next = Step(rawValue: viewModel.step.rawValue + 1) {
+                                viewModel.step = next
+                            }
+                        }
+                        .disabled(viewModel.isMerging || viewModel.images.isEmpty)
+                    }
                 }
+                .padding(.top)
             }
-            .padding(.top)
+            .padding()
         }
-        .padding()
         .frame(minWidth: 600, minHeight: 400)
     }
 

--- a/MergePictures/Model/ImageItem.swift
+++ b/MergePictures/Model/ImageItem.swift
@@ -1,0 +1,8 @@
+import Foundation
+import AppKit
+
+struct ImageItem: Identifiable, Equatable {
+    let id = UUID()
+    let url: URL
+    let image: NSImage
+}

--- a/MergePictures/Views/ImageSidebarView.swift
+++ b/MergePictures/Views/ImageSidebarView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct ImageSidebarView: View {
+    @ObservedObject var viewModel: AppViewModel
+    @State private var hoveredId: UUID?
+
+    var body: some View {
+        List {
+            ForEach(viewModel.images) { item in
+                SidebarRow(item: item,
+                           hoveredId: $hoveredId,
+                           deleteAction: { delete(item) })
+            }
+            .onMove(perform: move)
+        }
+        .listStyle(.sidebar)
+        .frame(minWidth: 200)
+    }
+
+    private func move(from source: IndexSet, to destination: Int) {
+        viewModel.images.move(fromOffsets: source, toOffset: destination)
+        viewModel.updatePreview()
+    }
+
+    private func delete(_ item: ImageItem) {
+        if let idx = viewModel.images.firstIndex(where: { $0.id == item.id }) {
+            viewModel.images.remove(at: idx)
+            viewModel.updatePreview()
+        }
+    }
+}
+
+private struct SidebarRow: View {
+    let item: ImageItem
+    @Binding var hoveredId: UUID?
+    var deleteAction: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(nsImage: item.image)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 40, height: 40)
+                .cornerRadius(4)
+            Text(item.url.lastPathComponent)
+                .lineLimit(1)
+            Spacer()
+            Button(action: deleteAction) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .opacity(hoveredId == item.id ? 1 : 0)
+        }
+        .padding(.vertical, 2)
+        .onHover { hovering in
+            hoveredId = hovering ? item.id : nil
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    ImageSidebarView(viewModel: .preview)
+}
+#endif


### PR DESCRIPTION
## Summary
- create `ImageSidebarView` with drag-and-drop reordering and delete controls
- add new `ImageItem` model type
- update `AppViewModel` to track `ImageItem` objects
- integrate sidebar into `ContentView`

## Testing
- `swift build -c debug` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68899c63e18c8321b6289cc14e210884