### PR TITLE
Implement rotating image order in Step1

### DIFF
--- a/MergePictures/ViewModel/AppViewModel.swift
+++ b/MergePictures/ViewModel/AppViewModel.swift
@@ -43,12 +43,24 @@ class AppViewModel: ObservableObject {
         sortImages()
     }
 
-    /// Cycles the image order by moving the first item to the end.
-    /// Clears any generated results and refreshes the preview.
+    /// Rotates image order within each mergeCount-sized group.
+    /// For example, with mergeCount 3 and images [1,2,3,4,5], the result will be
+    /// [2,3,1,5,4]. Results and preview are cleared after rearranging.
     func rotateImages() {
         guard images.count > 1 else { return }
-        let first = images.removeFirst()
-        images.append(first)
+        var newOrder: [ImageItem] = []
+        var index = 0
+        while index < images.count {
+            let end = min(index + mergeCount, images.count)
+            var group = Array(images[index..<end])
+            if group.count > 1 {
+                let first = group.removeFirst()
+                group.append(first)
+            }
+            newOrder.append(contentsOf: group)
+            index += mergeCount
+        }
+        images = newOrder
         mergedImages = []
         updatePreview()
     }

--- a/MergePictures/ViewModel/AppViewModel.swift
+++ b/MergePictures/ViewModel/AppViewModel.swift
@@ -43,6 +43,16 @@ class AppViewModel: ObservableObject {
         sortImages()
     }
 
+    /// Cycles the image order by moving the first item to the end.
+    /// Clears any generated results and refreshes the preview.
+    func rotateImages() {
+        guard images.count > 1 else { return }
+        let first = images.removeFirst()
+        images.append(first)
+        mergedImages = []
+        updatePreview()
+    }
+
     /// Sorts images by filename using Finder-like logic respecting the current sort order.
     func sortImages() {
         images.sort { a, b in

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -15,7 +15,7 @@ struct Step1View: View {
             }
             .pickerStyle(SegmentedPickerStyle())
             Spacer()
-            Button("Swap Order") {}
+            Button("Swap Order") { viewModel.rotateImages() }
             Text("Selected: \(viewModel.images.count)")
             Spacer()
         }


### PR DESCRIPTION
## Summary
- add `rotateImages` method in `AppViewModel` to cycle image order
- hook up the existing "Swap Order" button in `Step1View`

## Testing
- `swiftc -typecheck MergePictures/ContentView.swift MergePictures/Views/Step1View.swift MergePictures/ViewModel/AppViewModel.swift MergePictures/Views/ImageSidebarView.swift MergePictures/Views/Step2View.swift MergePictures/Views/Step3View.swift MergePictures/Views/StepIndicator.swift MergePictures/Model/ImageItem.swift MergePictures/Model/MergeDirection.swift MergePictures/Model/Step.swift MergePictures/MergePicturesApp.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6889f8b62c648321a179256f16789298