### PR TITLE
Add unified zoom slider at toolbar

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -3,6 +3,31 @@ import SwiftUI
 struct ContentView: View {
     @StateObject private var viewModel: AppViewModel
 
+    private var currentPreviewScale: Binding<CGFloat> {
+        Binding(
+            get: {
+                switch viewModel.step {
+                case .selectImages:
+                    return viewModel.step1PreviewScale
+                case .previewAll:
+                    return viewModel.step2PreviewScale
+                default:
+                    return 1.0
+                }
+            },
+            set: { newValue in
+                switch viewModel.step {
+                case .selectImages:
+                    viewModel.step1PreviewScale = newValue
+                case .previewAll:
+                    viewModel.step2PreviewScale = newValue
+                default:
+                    break
+                }
+            }
+        )
+    }
+
     init(viewModel: AppViewModel = AppViewModel()) {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
@@ -37,6 +62,9 @@ struct ContentView: View {
                             }
                         }
                         .disabled(viewModel.isMerging || viewModel.images.isEmpty)
+                    }
+                    if viewModel.step == .selectImages || viewModel.step == .previewAll {
+                        PreviewScaleSlider(scale: currentPreviewScale)
                     }
                 }
                 .padding(.top)

--- a/MergePictures/ViewModel/AppViewModel.swift
+++ b/MergePictures/ViewModel/AppViewModel.swift
@@ -32,6 +32,8 @@ class AppViewModel: ObservableObject {
     @Published var isExporting: Bool = false
     @Published var exportProgress: Double = 0
     @Published var sortAscending: Bool = true
+    @Published var step1PreviewScale: CGFloat = 1.0
+    @Published var step2PreviewScale: CGFloat = 1.0
 
 
     func addImages(urls: [URL]) {
@@ -219,6 +221,8 @@ extension AppViewModel {
             guard let img = NSImage(named: "Placeholder\(idx)") else { return nil }
             return ImageItem(url: URL(fileURLWithPath: "placeholder\(idx).png"), image: img)
         }
+        vm.step1PreviewScale = 1.0
+        vm.step2PreviewScale = 1.0
         vm.updatePreview()
         vm.batchMerge()
         return vm

--- a/MergePictures/Views/PreviewScaleSlider.swift
+++ b/MergePictures/Views/PreviewScaleSlider.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct PreviewScaleSlider: View {
+    @Binding var scale: CGFloat
+
+    var body: some View {
+        Slider(value: $scale, in: 0.8...3)
+            .frame(width: 150)
+    }
+}
+
+#if DEBUG
+#Preview {
+    PreviewScaleSlider(scale: .constant(1.0))
+}
+#endif

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -45,9 +45,9 @@ struct Step1View: View {
     }
 
     private func previewImage(for image: NSImage, in proxy: GeometryProxy) -> some View {
-        let heightScale = min(proxy.size.height / image.size.height, 1)
-        var width = image.size.width * heightScale
-        var frameHeight: CGFloat? = image.size.height * heightScale
+        let baseScale = min(proxy.size.height / image.size.height, 1)
+        var width = image.size.width * baseScale * viewModel.step1PreviewScale
+        var frameHeight: CGFloat? = image.size.height * baseScale * viewModel.step1PreviewScale
         if width < proxy.size.width * 0.5 {
             width = proxy.size.width * 0.5
             frameHeight = nil

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -2,10 +2,8 @@ import SwiftUI
 
 struct Step2View: View {
     @ObservedObject var viewModel: AppViewModel
-    @State private var scale: CGFloat = 1.0
-
     private var gridLayout: [GridItem] {
-        [GridItem(.adaptive(minimum: 150 * scale))]
+        [GridItem(.adaptive(minimum: 150 * viewModel.step2PreviewScale))]
     }
     var body: some View {
 
@@ -13,11 +11,6 @@ struct Step2View: View {
             if viewModel.isMerging {
                 ProgressView(value: viewModel.mergeProgress)
                     .padding(.vertical)
-            }
-            HStack {
-                Spacer()
-                Slider(value: $scale, in: 0.8...3)
-                    .frame(width: 150)
             }
             ScrollView {
                 if viewModel.mergedImages.isEmpty {
@@ -31,7 +24,7 @@ struct Step2View: View {
                             Image(nsImage: img)
                                 .resizable()
                                 .scaledToFit()
-                                .frame(height: 150 * scale)
+                                .frame(height: 150 * viewModel.step2PreviewScale)
                                 .overlay(
                                     Text("\(idx + 1)")
                                         .foregroundColor(.white)
@@ -40,7 +33,7 @@ struct Step2View: View {
                                 )
                         }
                     }
-                    .animation(.default, value: scale)
+                    .animation(.default, value: viewModel.step2PreviewScale)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- centralize preview scaling slider in the navigation toolbar
- adjust slider binding to control Step1 or Step2 based on active step
- remove old sliders from Step1View and Step2View

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project MergePictures.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889fced17248321a853111d6a87a9e5