### PR TITLE
Unify preview scale controls for step views

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -47,7 +47,7 @@ struct ContentView: View {
                 ToolbarItem(placement: .automatic) {
                     HStack {
                         Image(systemName: "magnifyingglass")
-                        Slider(value: $viewModel.step1PreviewScale, in: 0.5...2.0)
+                        Slider(value: previewScaleBinding, in: 0.5...2.0)
                     }
                     .frame(width: 150)
                     .tint(.accentColor)
@@ -55,6 +55,17 @@ struct ContentView: View {
             }
         }
         .frame(minWidth: 850, minHeight: 400)
+    }
+
+    private var previewScaleBinding: Binding<CGFloat> {
+        switch viewModel.step {
+        case .selectImages:
+            return $viewModel.step1PreviewScale
+        case .previewAll:
+            return $viewModel.step2PreviewScale
+        case .export:
+            return .constant(1.0)
+        }
     }
 
     @ViewBuilder

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -12,10 +12,6 @@ struct Step2View: View {
                 ProgressView(value: viewModel.mergeProgress)
                     .padding(.vertical)
             }
-            HStack {
-                Spacer()
-                PreviewScaleSlider(scale: $viewModel.step2PreviewScale)
-            }
             ScrollView {
                 if viewModel.mergedImages.isEmpty {
                     reloadPrompt


### PR DESCRIPTION
## Summary
- link the toolbar slider to the current step's scale value
- remove outdated slider from Step2View

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_688a042a2fd88321b41525b3514e2d0c