### PR TITLE
Fix vertical preview scaling

### DIFF
--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -45,13 +45,21 @@ struct Step1View: View {
     }
 
     private func previewImage(for image: NSImage, in proxy: GeometryProxy) -> some View {
-        let baseScale = min(proxy.size.height / image.size.height, 1)
+        let baseScale: CGFloat
+        if viewModel.direction == .vertical {
+            baseScale = min(proxy.size.width / image.size.width, 1)
+        } else {
+            baseScale = min(proxy.size.height / image.size.height, 1)
+        }
+
         var width = image.size.width * baseScale * viewModel.step1PreviewScale
         var frameHeight: CGFloat? = image.size.height * baseScale * viewModel.step1PreviewScale
+
         if width < proxy.size.width * 0.5 {
             width = proxy.size.width * 0.5
             frameHeight = nil
         }
+
         return Image(nsImage: image)
             .resizable()
             .scaledToFit()

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -60,10 +60,12 @@ struct Step1View: View {
             frameHeight = nil
         }
 
-        return Image(nsImage: image)
-            .resizable()
-            .scaledToFit()
-            .frame(width: width, height: frameHeight)
+        return ScrollView {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(width: width, height: frameHeight)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- adjust scaling logic when merging vertically so the preview width is calculated from container width
- ensure App Sandbox remains disabled

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688a19772c048321a0818f7968c7c655