### PR TITLE
Fix dark mode numbering

### DIFF
--- a/MergePictures/Views/ImageSidebarView.swift
+++ b/MergePictures/Views/ImageSidebarView.swift
@@ -67,6 +67,7 @@ private struct SidebarRow: View {
             Spacer()
             Button(action: deleteAction) {
                 Image(systemName: "trash")
+                    .foregroundColor(.primary)
             }
             .buttonStyle(.borderless)
             .opacity(hoveredId == item.id ? 1 : 0)

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct Step2View: View {
     @ObservedObject var viewModel: AppViewModel
+    @Environment(\.colorScheme) private var colorScheme
     private var gridLayout: [GridItem] {
         [GridItem(.adaptive(minimum: 150 * viewModel.step2PreviewScale))]
     }
@@ -25,12 +26,13 @@ struct Step2View: View {
                                 .resizable()
                                 .scaledToFit()
                                 .frame(height: 150 * viewModel.step2PreviewScale)
-                                .overlay(
+                                .overlay(alignment: .bottomTrailing) {
                                     Text("\(idx + 1)")
-                                        .foregroundColor(.white)
-                                        .padding(4),
-                                    alignment: .bottomTrailing
-                                )
+                                        .fontWeight(.bold)
+                                        .foregroundColor(colorScheme == .dark ? .white : .black)
+                                        .shadow(color: colorScheme == .dark ? .black.opacity(0.8) : .white.opacity(0.8), radius: 1)
+                                        .padding(4)
+                                }
                         }
                     }
                     .animation(.default, value: viewModel.step2PreviewScale)


### PR DESCRIPTION
## Summary
- add adaptive text color and shadow to Step2 numbering
- ensure sidebar trash button adopts primary color

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688a1e3950c48321a87c214079406cee