### PR TITLE
Refactor Step1 layout to fix NavigationSplitView animation

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -39,9 +39,9 @@ struct ContentView: View {
                         .disabled(viewModel.isMerging || viewModel.images.isEmpty)
                     }
                 }
-                .padding(.top)
+//                .padding(.top)
             }
-            .frame(minWidth: 600)
+//            .frame(minWidth: 600)
             .padding()
             .toolbar {
                 ToolbarItem(placement: .automatic) {
@@ -54,7 +54,7 @@ struct ContentView: View {
                 }
             }
         }
-        .frame(minWidth: 850, minHeight: 400)
+        
     }
 
     private var previewScaleBinding: Binding<CGFloat> {

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -35,7 +35,7 @@ struct Step1View: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .padding(.bottom)
+//        .padding(.bottom)
     }
 
     private var settingsSection: some View {
@@ -66,7 +66,7 @@ struct Step1View: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer()
-        }
+        }.padding(.leading)
     }
 
     private func previewImage(for image: NSImage, in proxy: GeometryProxy) -> some View {

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -2,67 +2,70 @@ import SwiftUI
 
 struct Step1View: View {
     @ObservedObject var viewModel: AppViewModel
-    @State public var showImporter = false
+    @State private var showImporter = false
 
     var body: some View {
-        GeometryReader { geometry in
-            HStack {
+        HStack(spacing: 0) {
+            previewSection
+            Divider()
+            settingsSection
+                .frame(width: 280)
+        }
+        .fileImporter(isPresented: $showImporter, allowedContentTypes: [.image], allowsMultipleSelection: true) { result in
+            if case let .success(urls) = result {
+                viewModel.addImages(urls: urls)
+            }
+        }
+    }
+
+    private var previewSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            GeometryReader { proxy in
                 Group {
-                    VStack(alignment: .leading, spacing: 16) {
-                        GeometryReader { proxy in
-                            Group {
-                                if let img = viewModel.previewImage {
-                                    ScrollView([.vertical ,.horizontal]){
-                                        previewImage(for: img, in: proxy)
-                                    }
-                                } else {
-                                    Text("No Preview")
-                                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                }
-                            }
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    if let img = viewModel.previewImage {
+                        ScrollView([.vertical, .horizontal]) {
+                            previewImage(for: img, in: proxy)
                         }
-                        .frame(minHeight: geometry.size.height)
+                    } else {
+                        Text("No Preview")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                    .padding(.bottom)
-                    .fileImporter(isPresented: $showImporter, allowedContentTypes: [.image], allowsMultipleSelection: true) { result in
-                        if case let .success(urls) = result {
-                            viewModel.addImages(urls: urls)
-                        }
-                    }
-                }.frame(width: geometry.size.width * 2/3)
-                Divider()
-                VStack(alignment: .leading) {
-                    Button("Add Images") {
-                        showImporter = true
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-//                    .padding()
-                    
-                    Text("Basic Settings").bold().padding(.top)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(.bottom)
+    }
 
-                    Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+    private var settingsSection: some View {
+        VStack(alignment: .leading) {
+            Button("Add Images") {
+                showImporter = true
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-                    Picker("Direction", selection: $viewModel.direction) {
-                        ForEach(MergeDirection.allCases) { dir in
-                            Text(dir.rawValue.capitalized).tag(dir)
-                        }
-                    }
-                    .pickerStyle(SegmentedPickerStyle())
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Basic Settings").bold().padding(.top)
 
-                    Text("Advance Settings").bold().padding(.top)
+            Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                    Button("Swap Order") {
-                        viewModel.rotateImages()
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    Spacer()
+            Picker("Direction", selection: $viewModel.direction) {
+                ForEach(MergeDirection.allCases) { dir in
+                    Text(dir.rawValue.capitalized).tag(dir)
                 }
             }
+            .pickerStyle(SegmentedPickerStyle())
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text("Advance Settings").bold().padding(.top)
+
+            Button("Swap Order") {
+                viewModel.rotateImages()
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer()
         }
     }
 


### PR DESCRIPTION
## Summary
- restructure Step1View into preview and settings sections
- maintain responsive SwiftUI layout and keep App Sandbox disabled

## Testing
- `swiftc MergePictures/Views/Step1View.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_688b3ccbf9948321b580c7000d0b138c