### PR TITLE
feat: add iOS support with platform-specific views

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -7,54 +7,63 @@ struct ContentView: View {
         _viewModel = StateObject(wrappedValue: viewModel)
     }
     var body: some View {
+        #if os(macOS)
         NavigationSplitView {
             ImageSidebarView(viewModel: viewModel)
                 .navigationSplitViewColumnWidth(min: 150, ideal: 200, max: 400)
         } detail: {
-            VStack(spacing: 10) {
-                StepIndicator(current: $viewModel.step)
-                Divider()
+            detailContent
+        }
+        #else
+        NavigationStack {
+            detailContent
+        }
+        #endif
+    }
 
-                VStack(alignment: .leading, spacing: 16) {
-                    content
-                }
-                .frame(maxWidth: .infinity, alignment: .top)
+    private var detailContent: some View {
+        VStack(spacing: 10) {
+            StepIndicator(current: $viewModel.step)
+            Divider()
 
-                HStack {
-                    if viewModel.step != .selectImages {
-                        Button("Back") {
-                            if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
-                                viewModel.step = prev
-                            }
-                        }
-                        .disabled(viewModel.isExporting)
-                    }
-                    Spacer()
-                    if viewModel.step != .export {
-                        Button("Next") {
-                            if let next = Step(rawValue: viewModel.step.rawValue + 1) {
-                                viewModel.step = next
-                            }
-                        }
-                        .disabled(viewModel.isMerging || viewModel.images.isEmpty)
-                    }
-                }
-//                .padding(.top)
+            VStack(alignment: .leading, spacing: 16) {
+                content
             }
-//            .frame(minWidth: 600)
-            .padding()
-            .toolbar {
-                ToolbarItem(placement: .automatic) {
-                    HStack {
-                        Image(systemName: "magnifyingglass")
-                        Slider(value: previewScaleBinding, in: 0.5...2.0)
+            .frame(maxWidth: .infinity, alignment: .top)
+
+            HStack {
+                if viewModel.step != .selectImages {
+                    Button("Back") {
+                        if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
+                            viewModel.step = prev
+                        }
                     }
-                    .frame(width: 150)
-                    .tint(.accentColor)
+                    .disabled(viewModel.isExporting)
+                }
+                Spacer()
+                if viewModel.step != .export {
+                    Button("Next") {
+                        if let next = Step(rawValue: viewModel.step.rawValue + 1) {
+                            viewModel.step = next
+                        }
+                    }
+                    .disabled(viewModel.isMerging || viewModel.images.isEmpty)
                 }
             }
         }
-        
+        .padding()
+        #if os(macOS)
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                    Slider(value: previewScaleBinding, in: 0.5...2.0)
+                }
+                .frame(width: 150)
+                .tint(.accentColor)
+            }
+        }
+        #endif
     }
 
     private var previewScaleBinding: Binding<CGFloat> {

--- a/MergePictures/Model/ImageItem.swift
+++ b/MergePictures/Model/ImageItem.swift
@@ -1,8 +1,7 @@
 import Foundation
-import AppKit
 
 struct ImageItem: Identifiable, Equatable {
     let id = UUID()
     let url: URL
-    let image: NSImage
+    let image: PlatformImage
 }

--- a/MergePictures/PlatformImage.swift
+++ b/MergePictures/PlatformImage.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftUI
+#if os(macOS)
+import AppKit
+public typealias PlatformImage = NSImage
+#else
+import UIKit
+public typealias PlatformImage = UIImage
+#endif
+
+public extension Image {
+    init(platformImage: PlatformImage) {
+        #if os(macOS)
+        self.init(nsImage: platformImage)
+        #else
+        self.init(uiImage: platformImage)
+        #endif
+    }
+}
+
+public func loadPlatformImage(from url: URL) -> PlatformImage? {
+    #if os(macOS)
+    return NSImage(contentsOf: url)
+    #else
+    return UIImage(contentsOfFile: url.path)
+    #endif
+}
+
+public func platformImageNamed(_ name: String) -> PlatformImage? {
+    #if os(macOS)
+    return NSImage(named: name)
+    #else
+    return UIImage(named: name)
+    #endif
+}

--- a/MergePictures/Views/ImageSidebarView.swift
+++ b/MergePictures/Views/ImageSidebarView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import SwiftUI
 import AppKit
 
@@ -86,4 +87,6 @@ private struct SidebarRow: View {
 #Preview {
     ImageSidebarView(viewModel: .preview)
 }
+#endif
+
 #endif

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -69,7 +69,7 @@ struct Step1View: View {
         }.padding(.leading)
     }
 
-    private func previewImage(for image: NSImage, in proxy: GeometryProxy) -> some View {
+    private func previewImage(for image: PlatformImage, in proxy: GeometryProxy) -> some View {
         let baseScale: CGFloat
         if viewModel.direction == .vertical {
             baseScale = min(proxy.size.width / image.size.width, 1)
@@ -85,7 +85,7 @@ struct Step1View: View {
             frameHeight = nil
         }
 
-        return Image(nsImage: image)
+        return Image(platformImage: image)
                     .resizable()
                     .scaledToFit()
                     .frame(width: width, height: frameHeight)

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -22,7 +22,7 @@ struct Step2View: View {
                         ForEach(Array(viewModel.mergedImages.enumerated()), id: \.offset) { pair in
                             let idx = pair.offset
                             let img = pair.element
-                            Image(nsImage: img)
+                            Image(platformImage: img)
                                 .resizable()
                                 .scaledToFit()
                                 .frame(height: 150 * viewModel.step2PreviewScale)

--- a/MergePictures/Views/Step3View.swift
+++ b/MergePictures/Views/Step3View.swift
@@ -1,5 +1,7 @@
-import AppKit
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 struct Step3View: View {
     @ObservedObject var viewModel: AppViewModel
@@ -22,6 +24,7 @@ struct Step3View: View {
     }
 
     func exportImages() {
+        #if os(macOS)
         let panel = NSOpenPanel()
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
@@ -29,6 +32,10 @@ struct Step3View: View {
         if panel.runModal() == .OK, let dir = panel.url {
             viewModel.exportAll(to: dir)
         }
+        #else
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        viewModel.exportAll(to: dir)
+        #endif
     }
 }
 


### PR DESCRIPTION
## Summary
- add cross-platform `PlatformImage` utilities for unified image handling
- adapt `ContentView` and step views for iOS while preserving macOS logic
- update view model with iOS-compatible merge and export routines

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688b484486348321b79d805723071952