### PR TITLE
Fix iOS layout to fill full screen height

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -42,6 +42,8 @@ struct ContentView: View {
             }
             .frame(maxWidth: .infinity, alignment: .top)
 
+            Spacer()
+
             HStack {
                 if viewModel.step != .selectImages {
                     Button("Back") {
@@ -62,6 +64,7 @@ struct ContentView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding()
         #if os(macOS)
         .toolbar {

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -7,7 +7,6 @@ struct Step2View: View {
         [GridItem(.adaptive(minimum: 150 * viewModel.step2PreviewScale))]
     }
     var body: some View {
-
         VStack {
             if viewModel.isMerging {
                 ProgressView(value: viewModel.mergeProgress)
@@ -38,7 +37,9 @@ struct Step2View: View {
                     .animation(.default, value: viewModel.step2PreviewScale)
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear {
             if viewModel.mergedImages.isEmpty {
                 viewModel.batchMerge()

--- a/MergePictures/Views/Step3View.swift
+++ b/MergePictures/Views/Step3View.swift
@@ -21,6 +21,7 @@ struct Step3View: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     func exportImages() {


### PR DESCRIPTION
## Summary
- Expand `detailContent` to use all available space and anchor navigation controls to the bottom
- Ensure Step 2 and Step 3 views stretch vertically to occupy the full screen on mobile

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d9e321f708321b810afc6e00f206a