### PR TITLE
Refine mobile UI for Apple-style navigation and settings

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -42,25 +42,37 @@ struct ContentView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 
-            HStack {
-                if viewModel.step != .selectImages {
+            let showBack = viewModel.step != .selectImages
+            let showNext = viewModel.step != .export
+
+            HStack(spacing: 16) {
+                if showBack {
                     Button("Back") {
                         if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
                             viewModel.step = prev
                         }
                     }
+                    .bold()
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .frame(maxWidth: showNext ? 150 : .infinity)
                     .disabled(viewModel.isExporting)
                 }
-                Spacer()
-                if viewModel.step != .export {
+
+                if showNext {
                     Button("Next") {
                         if let next = Step(rawValue: viewModel.step.rawValue + 1) {
                             viewModel.step = next
                         }
                     }
+                    .bold()
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                    .frame(maxWidth: .infinity)
                     .disabled(viewModel.isMerging || viewModel.images.isEmpty)
                 }
             }
+            .frame(maxWidth: .infinity)
         }
         .padding()
         .frame(maxHeight: .infinity)

--- a/MergePictures/Views/Step1View.swift
+++ b/MergePictures/Views/Step1View.swift
@@ -18,11 +18,8 @@ struct Step1View: View {
                 previewSection
                     .frame(height: proxy.size.height * 0.6)
                 Divider()
-                ScrollView {
-                    settingsSection
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(height: proxy.size.height * 0.4)
+                settingsSection
+                    .frame(height: proxy.size.height * 0.4)
             }
         }
         .onChange(of: selectedItems) { newItems in
@@ -67,18 +64,39 @@ struct Step1View: View {
     }
 
     private var settingsSection: some View {
-        VStack(alignment: .leading) {
 #if os(iOS)
-            PhotosPicker(selection: $selectedItems, maxSelectionCount: 0, matching: .images) {
-                Text("Add Images")
+        Form {
+            Section {
+                PhotosPicker(selection: $selectedItems, maxSelectionCount: 0, matching: .images) {
+                    Label("Add Images", systemImage: "photo.on.rectangle.angled")
+                }
+                .controlSize(.large)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Section("Basic Settings") {
+                Stepper("Merge count: \(viewModel.mergeCount)", value: $viewModel.mergeCount, in: 1...10)
+                Picker("Direction", selection: $viewModel.direction) {
+                    ForEach(MergeDirection.allCases) { dir in
+                        Text(dir.rawValue.capitalized).tag(dir)
+                    }
+                }
+                .pickerStyle(SegmentedPickerStyle())
+            }
+
+            Section("Advanced Settings") {
+                Button("Swap Order") {
+                    viewModel.rotateImages()
+                }
+                .controlSize(.large)
+            }
+        }
+        .formStyle(.grouped)
 #else
+        VStack(alignment: .leading) {
             Button("Add Images") {
                 showImporter = true
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-#endif
 
             Text("Basic Settings").bold().padding(.top)
 
@@ -101,7 +119,9 @@ struct Step1View: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer()
-        }.padding(.leading)
+        }
+        .padding(.leading)
+#endif
     }
 
     private func previewImage(for image: PlatformImage, in proxy: GeometryProxy) -> some View {

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -53,6 +53,7 @@ struct Step2View: View {
                 viewModel.batchMerge()
             }
             .buttonStyle(.borderedProminent)
+            .controlSize(.large)
         }
         .padding()
         .background(

--- a/MergePictures/Views/Step3View.swift
+++ b/MergePictures/Views/Step3View.swift
@@ -22,14 +22,20 @@ struct Step3View: View {
                 }
                 #if os(macOS)
                 Button("Export") { exportImages() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
                     .disabled(viewModel.isExporting)
                 if viewModel.exportProgress == 1 && !viewModel.isExporting {
                     Text("Export Completed!").foregroundColor(.green)
                 }
                 #else
                 Button("Share") { exportImages() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
                     .disabled(viewModel.isExporting)
                 Button("Save to Photos") { saveToPhotos() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
                     .disabled(viewModel.isExporting)
                 if let msg = saveMessage {
                     Text(msg).foregroundColor(.green)


### PR DESCRIPTION
## Summary
- Style Back and Next as weighted, full-width buttons with bold labels for a native iOS/iPadOS feel
- Rework image selection settings into a grouped `Form` with large controls
- Enlarge action buttons across preview and export steps for consistency

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -list` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_688eee6a632483219fd383dae471e6de