### PR TITLE
Rework navigation controls for step flow

### DIFF
--- a/MergePictures/ContentView.swift
+++ b/MergePictures/ContentView.swift
@@ -44,59 +44,54 @@ struct ContentView: View {
 
             let showBack = viewModel.step != .selectImages
             let showNext = viewModel.step != .export
-            GeometryReader { geo in
-                HStack(spacing: 16) {
-                    if showBack && showNext {
-                        Button("Back") {
-                            if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
-                                viewModel.step = prev
-                            }
+            HStack(spacing: 16) {
+                if showBack && showNext {
+                    Button("Back") {
+                        if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
+                            viewModel.step = prev
                         }
-                        .bold()
-                        .buttonStyle(.bordered)
-                        .frame(maxWidth: .infinity)
-                        .controlSize(.large)
-                        .disabled(viewModel.isExporting)
-
-                        Button("Next") {
-                            if let next = Step(rawValue: viewModel.step.rawValue + 1) {
-                                viewModel.step = next
-                            }
-                        }
-                        .bold()
-                        .buttonStyle(.borderedProminent)
-                        .frame(maxWidth: .infinity)
-                        .controlSize(.large)
-                        .disabled(viewModel.isMerging || viewModel.images.isEmpty)
-                    } else if showBack {
-//                        Spacer()
-                        Button("Back") {
-                            if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
-                                viewModel.step = prev
-                            }
-                        }
-                        .bold()
-                        .buttonStyle(.bordered)
-                        .frame(maxWidth: .infinity)
-                        .controlSize(.large)
-                        .disabled(viewModel.isExporting)
-//                        Spacer()
-                    } else if showNext {
-//                        Spacer()
-                        Button("Next") {
-                            if let next = Step(rawValue: viewModel.step.rawValue + 1) {
-                                viewModel.step = next
-                            }
-                        }
-                        .bold()
-                        .buttonStyle(.borderedProminent)
-                        .frame(maxWidth: .infinity)
-                        .controlSize(.large)
-                        .disabled(viewModel.isMerging || viewModel.images.isEmpty)
-//                        Spacer()
                     }
+                    .bold()
+                    .buttonStyle(.bordered)
+                    .frame(width: 120)
+                    .controlSize(.large)
+                    .disabled(viewModel.isExporting)
+
+                    Button("Next") {
+                        if let next = Step(rawValue: viewModel.step.rawValue + 1) {
+                            viewModel.step = next
+                        }
+                    }
+                    .bold()
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+                    .controlSize(.large)
+                    .disabled(viewModel.isMerging || viewModel.images.isEmpty)
+                } else if showBack {
+                    Button("Back") {
+                        if let prev = Step(rawValue: viewModel.step.rawValue - 1) {
+                            viewModel.step = prev
+                        }
+                    }
+                    .bold()
+                    .buttonStyle(.bordered)
+                    .frame(maxWidth: .infinity)
+                    .controlSize(.large)
+                    .disabled(viewModel.isExporting)
+                } else if showNext {
+                    Button("Next") {
+                        if let next = Step(rawValue: viewModel.step.rawValue + 1) {
+                            viewModel.step = next
+                        }
+                    }
+                    .bold()
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+                    .controlSize(.large)
+                    .disabled(viewModel.isMerging || viewModel.images.isEmpty)
                 }
             }
+            .frame(maxWidth: .infinity)
             .frame(height: 50)
         }
 //        .padding()


### PR DESCRIPTION
## Summary
- streamline navigation bar to use bold, full-width buttons
- keep Back button a fixed width while Next stretches when both are visible
- allow single Back or Next button to span the full horizontal space

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_688efcb8ecd883218000b17bb16786ea