### PR TITLE
Fix macOS build issues

### DIFF
--- a/MergePictures/ViewModel/AppViewModel.swift
+++ b/MergePictures/ViewModel/AppViewModel.swift
@@ -3,6 +3,8 @@ import Combine
 #if os(iOS)
 import UIKit
 import PhotosUI
+#endif
+#if canImport(Photos)
 import Photos
 #endif
 
@@ -458,7 +460,7 @@ class AppViewModel: ObservableObject {
                     PHPhotoLibrary.shared().performChanges({
                         PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: url)
                     }) { s, _ in
-                        success = success && s
+                        success = success && (s != false)
                         group.leave()
                     }
                     group.wait()

--- a/MergePictures/Views/Step2View.swift
+++ b/MergePictures/Views/Step2View.swift
@@ -97,9 +97,7 @@ private struct MergedThumbnail: View {
         }
         .task(id: scale) {
             image = nil
-            image = await Task.detached(priority: .userInitiated) {
-                loadPlatformImage(from: url, maxDimension: 400 * scale)
-            }.value
+            image = loadPlatformImage(from: url, maxDimension: 400 * scale)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Photos framework import for macOS
- fix photo library save boolean handling
- simplify image loading to avoid NSImage Sendable errors on macOS

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f3276cac8832196ea601b164305e2