### PR TITLE
feat: add compression toggle and dynamic export resolution

### DIFF
--- a/MergePictures/Views/Step3View.swift
+++ b/MergePictures/Views/Step3View.swift
@@ -16,6 +16,8 @@ struct Step3View: View {
         ScrollView {
             VStack(alignment: .leading) {
                 Stepper("Max KB: \(viewModel.maxFileSizeKB)", value: $viewModel.maxFileSizeKB, in: 100...10000, step: 100)
+                    .disabled(!viewModel.enableCompression)
+                Toggle("Compress Output", isOn: $viewModel.enableCompression)
                 if viewModel.isExporting {
                     ProgressView(value: viewModel.exportProgress)
                         .padding(.vertical)


### PR DESCRIPTION
## Summary
- add user-facing compression toggle with dynamic export resolution estimation
- support full-resolution export when compression is disabled
- reduce peak memory usage during batch merges and compression passes

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c2fb058832182dc2b788626ce59